### PR TITLE
Update nl.tts

### DIFF
--- a/src/main/assets/tts_commands/nl.tts
+++ b/src/main/assets/tts_commands/nl.tts
@@ -40,7 +40,7 @@
 		"tts_set": "Tekst-naar-spraak versie 4 correct ingesteld",
 		"track_recalculated": "Route is herberekend",		
 		
-		"poi_alert_point_X": "Punt %S ligt op %D2 op %N5 uur",
+		"poi_alert_point_X": "Punt %S ligt op %D2 op %N1 uur",
 		"poi_alert_X_points": "%N1 punten in bereik",
 		
 		"heart_rate_value": "hartslag %N1"

--- a/src/main/assets/tts_commands/nl.tts
+++ b/src/main/assets/tts_commands/nl.tts
@@ -3,44 +3,44 @@
 	"language": "nl",
 	"actions_A": {
 		"action_dist": "na %D2 %A",
-		"arrive_at_dest": "bestemming bereikt",
-		"arrive_at_dest_dist": "%D2 van uw bestemming",
-		"straight": "rechtdoor",
-		"right_bear": "rechtsaf",
-		"right": "rechts",
-		"right_sharp": "scherp rechts",
-		"left_bear": "linksaf",
-		"left": "links",
-		"left_sharp": "scherp Links",
+		"arrive_at_dest": "u heeft uw bestemming bereikt",
+		"arrive_at_dest_dist": "na %D2 heeft u uw bestemming bereikt",
+		"straight": "ga rechtdoor",
+		"right_bear": "houd rechts aan",
+		"right": "sla rechts af",
+		"right_sharp": "scherpe bocht naar rechts",
+		"left_bear": "houd links aan",
+		"left": "sla links af",
+		"left_sharp": "scherpe bocht naar links",
 		"stay_right": "blijf rechts",
 		"stay_left": "blijf links",
-		"take_exit_right": "neem rechtse afslag",
-		"take_exit_left": "neem linkse afslag",
-		"take_ramp_straight": "neem oprit rechtdoor",
+		"take_exit_right": "neem afslag rechts",
+		"take_exit_left": "neem afslag links",
+		"take_ramp_straight": "neem oprit recht voor u",
 		"take_ramp_right": "neem oprit rechts",
 		"take_ramp_left": "neem oprit links",
-		"merge": "samenvoegen",
-		"merge_right": "rechts samenvoegen",
-		"merge_right_on": "rechts samenvoegen op %S",
-		"merge_left": "links samenvoegen",
-		"merge_left_on": "links samenvoegen op %S",
+		"merge": "invoegen",
+		"merge_right": "rechts invoegen",
+		"merge_right_on": "rechts invoegen op %S",
+		"merge_left": "links invoegen",
+		"merge_left_on": "links invoegen op %S",
 		"then": ", dan",
 		"turn_u-turn": "keer om",
 		"turn_u-turn_dist": "na %D2 keer om",
 		"recalculating": "herberekenen",
 		"roundabout_dist": "na %D2, rotonde",
-		"roundabout_dist_exit": "rotonde op %D2, neem %N2 afslag",
+		"roundabout_dist_exit": "na %D2, neem %N2 afslag op de rotonde",
 		"roundabout_exit": "%N2 afslag",
 		"pass_point": "%S",
 		"pass_point_dist": "na %D2 %S ",
 		"navigation_start_car": "laten we rijden",
 		"navigation_start_bicycle": "laten we fietsen",
 		"navigation_start_foot": "laten we gaan",
-		"navigation_too_far_from_track": "Track op %D2 op %N1 uur",
+		"navigation_too_far_from_track": "Track ligt op %D2 op %N1 uur",
 		"tts_set": "Tekst-naar-spraak versie 4 correct ingesteld",
-		"track_recalculated": "Weg is herberekend",		
+		"track_recalculated": "Route is herberekend",		
 		
-		"poi_alert_point_X": "%S",
+		"poi_alert_point_X": "Punt %S ligt op %D2 op %N5 uur",
 		"poi_alert_X_points": "%N1 punten in bereik",
 		
 		"heart_rate_value": "hartslag %N1"
@@ -49,18 +49,18 @@
 	    "__comment": "Parameter 'D1' is always used for simple static information like 'Distance is: xxx metres'",
 		"m": [
 			"%N1 meter, 1, 1",
-			"%N1 meters, 2, Inf",
-			"%NDec meters, 0, Inf"
+			"%N1 meter, 2, Inf",
+			"%NDec meter, 0, Inf"
 		],
 		"km": [
 			"%N1 kilometer, 1, 1",
-			"%N1 kilometers, 2, Inf",
-			"%NDec kilometers, 0, Inf"
+			"%N1 kilometer, 2, Inf",
+			"%NDec kilometer, 0, Inf"
 		],
 		"yd": [
 			"%N1 yard, 1, 1",
-			"%N1 yards, 2, Inf",
-			"%NDec yards, 0, Inf"
+			"%N1 yard, 2, Inf",
+			"%NDec yard, 0, Inf"
 		],
 		"ft": [
 			"%N1 voet, 1, 1",
@@ -69,8 +69,8 @@
 		],
 		"mi": [
 			"%N1 mijl, 1, 1",
-			"%N1 mijlen, 2, Inf",
-			"%NDec mijlen, 0, Inf"
+			"%N1 mijl, 2, Inf",
+			"%NDec mijl, 0, Inf"
 		]
 	},
 	"distances_D2": {
@@ -81,21 +81,21 @@
 	    "__comment": "Parameter 'V1' is always used for simple static information like 'Speed is: xxx metres'",
         "kmh": [
             "%N1 kilometer per uur, 1, 1",
-            "%N1 kilometers per uur, 2, Inf",
-            "%NDec kilometers per uur, 0, Inf"
+            "%N1 kilometer per uur, 2, Inf",
+            "%NDec kilometer per uur, 0, Inf"
         ],
         "milh": [
             "%N1 mijl per uur, 1, 1",
             "%N1 mijl per uur, 2, Inf",
-            "%NDec mijlen per uur, 0, Inf"
+            "%NDec mijl per uur, 0, Inf"
         ],
         "nmih": [
             "%N1 zeemijl per uur, 1, 1",
             "%N1 zeemijl per uur, 2, Inf",
-            "%NDec zeemijlen per uur, 0, Inf"
+            "%NDec zeemijl per uur, 0, Inf"
         ],
         "knot": [
-            "%N1 kopent, 1, 1",
+            "%N1 knoop, 1, 1",
             "%N1 knopen, 2, Inf",
             "%NDec knopen, 0, Inf"
         ]
@@ -105,7 +105,7 @@
         "hours": [
              "%N1 uren, 0, 0",
              "%N1 uur, 1, 1",
-            "%N1 uren, 2, Inf"
+            "%N1 uur, 2, Inf"
         ],
         "minutes": [
             "%N1 minuten, 0, 0",
@@ -114,7 +114,7 @@
         ],
         "seconds": [
             "%N1 seconden, 0, 0",
-            "%N1 second, 1, 1",
+            "%N1 seconde, 1, 1",
             "%N1 seconden, 2, Inf"
         ]
     },


### PR DESCRIPTION
Proposal for the voice commands for Dutch language. 

Note the following: when I put file nl.tts in directory  /Locus/data/tts/, the voice navigation changes, but not to what is file in nl.tts. For example without nl.tts in that directory, the command for "left_bear" is "linksaf'. With proposed nl.tts it becomes "houd links aan", but when I change the file nl.tts for testing to "left_bear": "test houd links aan", then command it still "houd links aan". Also for command "turn_u-turn" it says 'maak een u-bocht" instead of "keer om" as defined in nl.tts. Apparently when nl.tts is in that directory the voice commands are retrieved from yet another source.
